### PR TITLE
 Implement AWS Bedrock Runtime integration

### DIFF
--- a/AwsBedRockSyncApi/AwsBedRockSyncApi.csproj
+++ b/AwsBedRockSyncApi/AwsBedRockSyncApi.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.Bedrock" Version="4.0.2.2" />
+    <PackageReference Include="AWSSDK.BedrockRuntime" Version="4.0.0.4" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.0.6" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.1" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.0.7" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/AwsBedRockSyncApi/Controllers/BedRockController.cs
+++ b/AwsBedRockSyncApi/Controllers/BedRockController.cs
@@ -1,0 +1,40 @@
+﻿using AwsBedRockSyncApi.Interfaces;
+using AwsBedRockSyncApi.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AwsBedRockSyncApi.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class BedRockController : ControllerBase
+    {
+        private readonly IBedrockService _bedrockService;
+
+        public BedRockController( IBedrockService bedrockService)
+        {
+           _bedrockService = bedrockService ?? throw new ArgumentNullException(nameof(bedrockService));
+        }
+
+        [HttpPost("generate-text")]
+        public async Task<IActionResult> GenerateTextAsync([FromBody] TextGenerationRequest request)
+        {
+            if (string.IsNullOrWhiteSpace(request.Prompt))
+            {
+                return BadRequest("Prompt cannot be empty.");
+            }
+            try
+            {
+                var generatedText = await _bedrockService.GenerateTextAsync(
+                    request.Prompt,
+                    request.MaxTokens);
+                return Ok( new { GeneratedText = generatedText });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, $"Error generating text: {ex.Message}");
+            }
+        }
+
+    }
+}

--- a/AwsBedRockSyncApi/Interfaces/IBedrockService.cs
+++ b/AwsBedRockSyncApi/Interfaces/IBedrockService.cs
@@ -1,0 +1,7 @@
+﻿namespace AwsBedRockSyncApi.Interfaces
+{
+    public interface IBedrockService
+    {
+        Task<string> GenerateTextAsync(string prompt, int maxTokens = 400);
+    }
+}

--- a/AwsBedRockSyncApi/Models/TextGenerationRequest.cs
+++ b/AwsBedRockSyncApi/Models/TextGenerationRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace AwsBedRockSyncApi.Models
+{
+    public class TextGenerationRequest
+    {
+        public string Prompt { get; set; }
+        public int MaxTokens { get; set; } = 400; 
+    }
+}

--- a/AwsBedRockSyncApi/Program.cs
+++ b/AwsBedRockSyncApi/Program.cs
@@ -1,3 +1,6 @@
+using AwsBedRockSyncApi.Interfaces;
+using AwsBedRockSyncApi.Services;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -6,6 +9,16 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+builder.Services.AddAWSService<Amazon.S3.IAmazonS3>(new Amazon.Extensions.NETCore.Setup.AWSOptions
+{
+    Credentials = new Amazon.Runtime.BasicAWSCredentials(
+        builder.Configuration["AWS:AccessKey"],
+        builder.Configuration["AWS:SecretKey"]),
+    Region = Amazon.RegionEndpoint.GetBySystemName(builder.Configuration["AWS:Region"] ?? "us-east-1")
+});
+
+builder.Services.AddScoped<IBedrockService, BedrockServices>();
 
 var app = builder.Build();
 

--- a/AwsBedRockSyncApi/Services/BedrockServices.cs
+++ b/AwsBedRockSyncApi/Services/BedrockServices.cs
@@ -1,0 +1,74 @@
+﻿using Amazon.BedrockRuntime;
+using Amazon.BedrockRuntime.Model;
+using AwsBedRockSyncApi.Interfaces;
+using Microsoft.AspNetCore.Components.Forms;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+
+namespace AwsBedRockSyncApi.Services
+{
+    public class BedrockServices : IBedrockService
+    {
+        private readonly AmazonBedrockRuntimeClient _bedrockClient;
+
+
+        private readonly string _titantextModelid = "amazon.titan-text-express-v1";
+
+        public BedrockServices(IConfiguration configuration)
+        {
+            _bedrockClient = new AmazonBedrockRuntimeClient(
+                configuration["AWS:AccessKey"],
+                configuration["AWS:SecretKey"],
+                Amazon.RegionEndpoint.GetBySystemName(configuration["Aws:Region"] ?? "us-east-1"));
+        }
+
+        public async Task<string> GenerateTextAsync(string prompt, int maxTokens = 400)
+        {
+            try
+            {
+                var requestBody = new 
+                {
+                    InputText = prompt,
+                    textGenerationConfig= new
+                    {
+                        MaxTokens = maxTokens,
+                        temparature= 0.7,
+                        topP=0.9,
+                        StopSequences = new string[] { }
+                    },
+                };
+
+                var jsonrequest= JsonSerializer.Serialize(requestBody);
+                var request = new InvokeModelRequest
+                {
+                    ModelId = _titantextModelid,
+                    Body = new MemoryStream(Encoding.UTF8.GetBytes(jsonrequest)),
+                    ContentType = "application/json"
+                };
+
+                var response = await _bedrockClient.InvokeModelAsync(request);
+
+                using var reader = new StreamReader(response.Body);
+                var responseBody = await reader.ReadToEndAsync();
+                var responseObject = JsonSerializer.Deserialize<JsonElement>(responseBody);
+
+                var generatedText =  responseObject.GetProperty("results").EnumerateArray().First()
+                                    .GetProperty("outputText").GetString();
+                return generatedText ?? string.Empty;
+            }
+
+            catch (Exception ex)
+            {
+
+                throw;
+            }
+           
+           
+        }
+
+    }
+
+    
+    
+}

--- a/AwsBedRockSyncApi/appsettings.json
+++ b/AwsBedRockSyncApi/appsettings.json
@@ -1,4 +1,14 @@
 {
+  "Applicationname": "AwsBedRockSyncApi",
+  "ElasticConfiguration": {
+    "Uri": "http://localhost:9200",
+    "DefaultIndex": "aws-bedrock-sync-api"
+  },
+  "AWS": {
+    "Region": "us-east-1",
+    "AccessKey": "YourAccessKey",
+    "Secretkey": "YourSecret"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
- Add BedrockServices implementation with Titan text model support
- Configure AWS credentials and region from appsettings.json
- Implement GenerateTextAsync method for text generation
- Set up model configuration with customizable parameters
- Add proper exception handling for API calls

Technical details:
- Integrate AWSSDK.BedrockRuntime package
- Configure AmazonBedrockRuntimeClient with AWS credentials
- Implement text generation using amazon.titan-text-express-v1 model
- Add JSON serialization/deserialization for request/response handling